### PR TITLE
Fix audit alert: denial of service

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "cson-parser": "^1.2.0",
-    "js-yaml": "^3.3.0",
+    "js-yaml": "^3.13.0",
     "lodash": "^4.17.11"
   },
   "devDependencies": {


### PR DESCRIPTION
The library needs to have 3.13.0 for js-yaml to fix the npm audit security warning. I wanted to make an issue for the repo, but didn't seem able to.